### PR TITLE
Extremely basic completion

### DIFF
--- a/semantic-php-wy-macro.el
+++ b/semantic-php-wy-macro.el
@@ -70,20 +70,13 @@ NAME is the group name, DECLS is the compound use declarations."
          (push decl result)))))
 
 (defun semantic-php-wy-macro-USEDECL (name &optional alias)
-  "Create a temporary tag for single use declaration.
+  "Create the relevant tags for single use declaration.
 
 NAME is the fully- or unqualified name, ALIAS is the optional alias."
   `(wisent-raw-tag
-    (semantic-tag-new-type
-     (or ,alias
-         ;; The last part of the name acts as an alias in PHP.
-         (car (last (split-string ,name "\\\\"))))
-     ;; TODO: Technically, the type could be anything. Not just a
-     ;; class, but there's no way to express that.
-     "class"
-     (list (semantic-tag-new-type ,name "class" nil nil))
-     nil
-     :kind 'alias)))
+    (semantic-tag-new-include
+     ,name
+     nil)))
 
 (defun semantic-php-wy-macro-USETYPE (decl type)
   "Set the type of a use declaration.

--- a/semantic-php.el
+++ b/semantic-php.el
@@ -213,6 +213,17 @@ re-parse part of the buffer."
         (car parts)
       parts)))
 
+(define-mode-local-override semantic-tag-include-filename php-mode (tag)
+  "Try to find file for class/interface TAG.
+
+Ask ede-php-autoload for the file of the class/interface."
+  (let ((name (semantic-tag-name tag)))
+    (if (and (bound-and-true-p ede-php-autoload-mode)
+             (ede-current-project))
+        (or (ede-php-autoload-find-class-def-file (ede-current-project) name)
+            name)
+      name)))
+
 (define-mode-local-override semantic-find-tags-included
   php-mode (&optional table)
   "Find all include/require tags in TABLE.


### PR DESCRIPTION
I've had this lying around forever, without really using it. Figure it there is a better chance of it going anywhere by putting it out there for other people to poke at.

It makes simple semantic completion work with ede-php-autoload. It doesn't work with properties, as semantic is convinced that properties should start with $, but that might be fixable by adjusting the tag generated by properties.

Haven't given it much real-world exercise as ede-php-autoload doesn't understand the Drupal 8 autoloader (who can blame it? Neither do I).
